### PR TITLE
Use `clojure` rather than `clj` in invocation examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ Within an `:alias` block:
   :lint/fix {:main-opts ["-m" "cljfmt-runner.fix"]}
 ```
 
-You can then run `check` with `clj -A:lint` and `fix` with `clj -A:lint:lint/fix`. You can, of course, name these aliases whatever you want.
+You can then run `check` with `clojure -A:lint` and `lint/fix` with `clojure -A:lint:lint/fix`.
+
+You can, of course, name these aliases whatever you want.
 
 It's advisable to find the most recent sha from this repo for latest features.
 


### PR DESCRIPTION
Because `clojure` is meant for running Clojure programs in non-interactive modes while `clj` is for running programs in interactive mode, e.g. a REPL.