### PR TITLE
Add support for building a native image for faster execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,27 @@ Alternatively, you can specify extra directories on the command line with the `-
 
 For example, using the alias setup from the example above, if you wanted to scan a `dev` directory for Clojure sources too then you could do this with `clj -A:lint -d dev`.
 
+## Building a Native Image/Executable
+
+cljfmt is a great tool, but it’s historically been not a great fit for situations wherein latency is crucial, such as in a [git pre-commit hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks). This is [probably](https://clojureverse.org/t/tricks-to-make-clojure-startup-time-faster/1176/13?u=avi) because it and its libraries are not currently [AOT-compiled](https://en.wikipedia.org/wiki/Ahead-of-time_compilation).
+
+To address this, this project currently supports compilation to a native image/executable via [GraalVM](https://www.graalvm.org/) and [clj.native-image](https://github.com/taylorwood/clj.native-image). (Currently only the `check` entrypoint works; there are some outstanding issues with compiling the `fix` entrypoint. This isn’t ideal but the `check` entrypoint should be sufficient for use cases such as git pre-commit hooks.)
+
+You can make your own native executable like so:
+
+1. Clone this project
+1. Download GraalVM and extract it somewhere on your system
+1. Run this in your terminal:
+   ```shell
+   export GRAALVM_HOME=/path/to/the/home/dir/within/the/graalvm/dir
+   cd /path/to/wherever/you/cloned/this/project
+   clojure -A:native-image-check
+   ```
+
+If that worked, you should see in the current dir a new file: `cljfmt-check`. Move that file to wherever you wish, and it should get the job done.
+
+(As a suggestion, some of us do this: `mv cljfmt-check ~/bin/cljfmt` — the shorter name is just more convenient.)
+
 ## License
 
 Distributed under the Eclipse Public License either version 2.0 or (at your option) any later version.
@@ -63,4 +84,3 @@ Distributed under the Eclipse Public License either version 2.0 or (at your opti
 Copyright © 2018 James Laverack.
 
 Portions of this code (in particular `src/cljfmt_runner/diff.clj`) are © 2016 James Reeves and taken from https://github.com/weavejester/cljfmt
-

--- a/deps.edn
+++ b/deps.edn
@@ -14,4 +14,17 @@
          :main-opts ["-m" "cognitect.test-runner"]}
 
   :lint {:main-opts ["-m" "cljfmt-runner.check"]}
-  :lint/fix {:main-opts ["-m" "cljfmt-runner.fix"]}}}
+  :lint/fix {:main-opts ["-m" "cljfmt-runner.fix"]}
+
+  :native-image-check {:override-deps
+                       {org.clojure/clojure {:mvn/version "1.8.0"}} ;; see https://github.com/taylorwood/clj.native-image/issues/3
+                       :extra-deps
+                       {clj.native-image
+                        {:git/url "https://github.com/taylorwood/clj.native-image.git"
+                         :sha "d97f25aa153e0f94139f5d03e60a345151815d4d"}}
+                       :main-opts ["-m clj.native-image cljfmt-runner.check"
+                                   "--report-unsupported-elements-at-runtime"
+                                   "-H:Name=cljfmt-check"
+                                   "-H:ReflectionConfigurationFiles=graal_reflection.json"]}}
+
+ :jvm-opts ["-Dclojure.compiler.direct-linking=true"]}

--- a/graal_reflection.json
+++ b/graal_reflection.json
@@ -1,0 +1,10 @@
+[
+    {
+        "name": "java.io.File",
+        "allDeclaredConstructors": true,
+        "allPublicConstructors": true,
+        "allDeclaredMethods": true,
+        "allPublicMethods": true,
+        "allPublicFields": true
+    }
+]

--- a/src/cljfmt_runner/check.clj
+++ b/src/cljfmt_runner/check.clj
@@ -1,7 +1,9 @@
 (ns cljfmt-runner.check
   (:require [cljfmt.core :as cljfmt]
             [cljfmt-runner.core :refer :all]
-            [cljfmt-runner.diff :as diff]))
+            [cljfmt-runner.diff :as diff])
+  ;; Required for compilation to a “native image” executable via GraalVM.
+  (:gen-class))
 
 (defn -main
   [& args]

--- a/src/cljfmt_runner/fix.clj
+++ b/src/cljfmt_runner/fix.clj
@@ -1,5 +1,7 @@
 (ns cljfmt-runner.fix
-  (:require [cljfmt-runner.core :refer :all]))
+  (:require [cljfmt-runner.core :refer :all])
+  ;; Required for compilation to a “native image” executable via GraalVM.
+  (:gen-class))
 
 (defn -main
   [& args]


### PR DESCRIPTION
I documented the motivation for this in the README, but I’ll copy it here just so you (@JamesLaverack) don’t have to go digging for it:

> cljfmt is a great tool, but it’s historically been not a great fit for situations wherein latency is crucial, such as in a [git pre-commit hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks). This is [probably](https://clojureverse.org/t/tricks-to-make-clojure-startup-time-faster/1176/13?u=avi) because it and its libraries are not currently [AOT-compiled](https://en.wikipedia.org/wiki/Ahead-of-time_compilation).
>
>  To address this, this project currently supports compilation to a native image/executable via [GraalVM](https://www.graalvm.org/) and [clj.native-image](https://github.com/taylorwood/clj.native-image). …

I couldn’t have made this work without [the assistance and expertise](https://github.com/taylorwood/clj.native-image/issues/3) of @taylorwood, author of [clj.native-image](https://github.com/taylorwood/clj.native-image/).

Thanks Taylor!